### PR TITLE
feat:ネットワークの同期をカスタムプロパティ・RPCを用いて実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+/[Aa]ssets/Photon/

--- a/Assets/Photon.meta
+++ b/Assets/Photon.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 98951132346795f438babe7a3183da43
+folderAsset: yes
+timeCreated: 1523536679
+licenseType: Store
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1103,6 +1103,7 @@ GameObject:
   m_Component:
   - component: {fileID: 421612229}
   - component: {fileID: 421612228}
+  - component: {fileID: 421612230}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -1139,6 +1140,18 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &421612230
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 421612227}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf2ed46bad36265488ef58ae4aad5fd7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &451817808
 GameObject:
   m_ObjectHideFlags: 0
@@ -5692,6 +5705,50 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!1 &1833823832
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1833823834}
+  - component: {fileID: 1833823833}
+  m_Layer: 0
+  m_Name: PlayerManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1833823833
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1833823832}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a7b3df40e87e29043b72dc9dc39c2853, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1833823834
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1833823832}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1923876203
 GameObject:
   m_ObjectHideFlags: 0
@@ -6122,3 +6179,4 @@ SceneRoots:
   - {fileID: 1279972297}
   - {fileID: 825181087}
   - {fileID: 184045879}
+  - {fileID: 1833823834}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -303,6 +303,7 @@ GameObject:
   - component: {fileID: 145941868}
   - component: {fileID: 145941869}
   - component: {fileID: 145941870}
+  - component: {fileID: 145941871}
   m_Layer: 0
   m_Name: Square (2)
   m_TagString: Untagged
@@ -436,6 +437,28 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &145941871
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 145941866}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 9
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
 --- !u!1 &184045877
 GameObject:
   m_ObjectHideFlags: 0
@@ -1104,6 +1127,7 @@ GameObject:
   - component: {fileID: 421612229}
   - component: {fileID: 421612228}
   - component: {fileID: 421612230}
+  - component: {fileID: 421612231}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -1152,6 +1176,28 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cf2ed46bad36265488ef58ae4aad5fd7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &421612231
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 421612227}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 10
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
 --- !u!1 &451817808
 GameObject:
   m_ObjectHideFlags: 0
@@ -1164,6 +1210,7 @@ GameObject:
   - component: {fileID: 451817810}
   - component: {fileID: 451817811}
   - component: {fileID: 451817812}
+  - component: {fileID: 451817813}
   m_Layer: 0
   m_Name: Square (5)
   m_TagString: Untagged
@@ -1297,6 +1344,28 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &451817813
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 451817808}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 8
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
 --- !u!1 &457846531
 GameObject:
   m_ObjectHideFlags: 0
@@ -1393,6 +1462,7 @@ GameObject:
   - component: {fileID: 497045366}
   - component: {fileID: 497045367}
   - component: {fileID: 497045368}
+  - component: {fileID: 497045369}
   m_Layer: 0
   m_Name: Square (3)
   m_TagString: Untagged
@@ -1526,6 +1596,28 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &497045369
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 497045364}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 7
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
 --- !u!1 &517490330
 GameObject:
   m_ObjectHideFlags: 0
@@ -2551,6 +2643,7 @@ GameObject:
   - component: {fileID: 771169814}
   - component: {fileID: 771169815}
   - component: {fileID: 771169816}
+  - component: {fileID: 771169817}
   m_Layer: 0
   m_Name: Square (6)
   m_TagString: Untagged
@@ -2684,6 +2777,28 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &771169817
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 771169812}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 6
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
 --- !u!1 &775206278
 GameObject:
   m_ObjectHideFlags: 0
@@ -3032,6 +3147,7 @@ GameObject:
   - component: {fileID: 826425173}
   - component: {fileID: 826425174}
   - component: {fileID: 826425175}
+  - component: {fileID: 826425176}
   m_Layer: 0
   m_Name: Square (8)
   m_TagString: Untagged
@@ -3165,6 +3281,28 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &826425176
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 826425171}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 5
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
 --- !u!1 &906450984
 GameObject:
   m_ObjectHideFlags: 0
@@ -3462,6 +3600,7 @@ GameObject:
   - component: {fileID: 980827643}
   - component: {fileID: 980827644}
   - component: {fileID: 980827645}
+  - component: {fileID: 980827646}
   m_Layer: 0
   m_Name: Square (4)
   m_TagString: Untagged
@@ -3595,6 +3734,28 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &980827646
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 980827641}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 4
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
 --- !u!1 &1006546951
 GameObject:
   m_ObjectHideFlags: 0
@@ -3718,6 +3879,7 @@ GameObject:
   - component: {fileID: 1049832537}
   - component: {fileID: 1049832538}
   - component: {fileID: 1049832539}
+  - component: {fileID: 1049832540}
   m_Layer: 0
   m_Name: Square (7)
   m_TagString: Untagged
@@ -3851,6 +4013,28 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &1049832540
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1049832535}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 3
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
 --- !u!1 &1056385336
 GameObject:
   m_ObjectHideFlags: 0
@@ -5259,6 +5443,7 @@ GameObject:
   - component: {fileID: 1664950687}
   - component: {fileID: 1664950688}
   - component: {fileID: 1664950689}
+  - component: {fileID: 1664950690}
   m_Layer: 0
   m_Name: Square (1)
   m_TagString: Untagged
@@ -5392,6 +5577,28 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &1664950690
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1664950685}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 2
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
 --- !u!1 &1673940090
 GameObject:
   m_ObjectHideFlags: 0
@@ -5572,6 +5779,7 @@ GameObject:
   - component: {fileID: 1756316152}
   - component: {fileID: 1756316153}
   - component: {fileID: 1756316154}
+  - component: {fileID: 1756316155}
   m_Layer: 0
   m_Name: Square (0)
   m_TagString: Untagged
@@ -5705,6 +5913,28 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!114 &1756316155
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1756316150}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 1
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
 --- !u!1 &1833823832
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CellController.cs
+++ b/Assets/Scripts/CellController.cs
@@ -5,16 +5,20 @@ using System.Collections.Generic;
 using Unity.VisualScripting;
 using UnityEngine;
 
-public class CellController : MonoBehaviour
+public class CellController : MonoBehaviourPunCallbacks
 {
-    private int PLAYER1 = 1;
-    private int PLAYER2 = 2;
-    private bool isOccupied = false;
+    private int PLAYER1 = 0;
+    private int PLAYER2 = 1;
+    private GameObject gameManager;
     private GameObject oObject, xObject;
     private int index;
+    PhotonView gManagerPhotonView;
 
     private void Start()
     {
+        gameManager = GameObject.Find("GameManager");
+        gManagerPhotonView = gameManager.GetComponent<PhotonView>();
+
         oObject = transform.Find("o").gameObject;
         xObject = transform.Find("x").gameObject; 
 
@@ -26,43 +30,50 @@ public class CellController : MonoBehaviour
         index = x + y * 3;
     }
 
-    // セルが占有されているかどうかを返す
-    public bool IsOccupied()
-    {
-        return isOccupied;
-    }
-
     // セルに印を付ける
     public bool MarkCell()
     {
-        int PlayerId = (int)PhotonNetwork.LocalPlayer.CustomProperties["PlayerID"];
-        if (!isOccupied){
-            isOccupied = true;
+        int playerId = (int)PhotonNetwork.LocalPlayer.CustomProperties["PlayerID"];
+        GManager gManager = gameManager.GetComponent<GManager>();
+        int turnNum = gManager.getTurnNum();
 
-            if (PlayerId == PLAYER1)
+        if (gManager.getBoard(index) == -1){
+            gManagerPhotonView.RPC("RpcSetBoard", RpcTarget.All, index, playerId);
+            if ((playerId == PLAYER1) && ((turnNum % 2) == PLAYER1))
             {
                 // oの印を表示する処理
                 if (oObject != null)
                 {
-                    oObject.SetActive(true);
+                    photonView.RPC(nameof(RpcDisplayO), RpcTarget.All);
                     return true;
                 }
             }
-            else if(PlayerId == PLAYER2)
+            else if((playerId == PLAYER2) && ((turnNum % 2) == PLAYER2))
             {
                 // xの印を表示する処理表示にする
                 if (xObject != null)
                 {
-                    xObject.SetActive(true);
+                    photonView.RPC(nameof(RpcDisplayX), RpcTarget.All);
                     return true;
                 }
             }
         }
+        
         return false;
     }
 
     public int getIndex()
     {
         return index;
+    }
+
+    [PunRPC]
+    private void RpcDisplayO(){
+        oObject.SetActive(true);
+    }
+
+    [PunRPC]
+    private void RpcDisplayX(){
+        xObject.SetActive(true);
     }
 }

--- a/Assets/Scripts/CellController.cs
+++ b/Assets/Scripts/CellController.cs
@@ -1,3 +1,5 @@
+using Photon.Pun;
+using Photon.Realtime;
 using System.Collections;
 using System.Collections.Generic;
 using Unity.VisualScripting;
@@ -5,6 +7,8 @@ using UnityEngine;
 
 public class CellController : MonoBehaviour
 {
+    private int PLAYER1 = 1;
+    private int PLAYER2 = 2;
     private bool isOccupied = false;
     private GameObject oObject, xObject;
     private int index;
@@ -29,12 +33,13 @@ public class CellController : MonoBehaviour
     }
 
     // セルに印を付ける
-    public bool MarkCell(int turn)
+    public bool MarkCell()
     {
+        int PlayerId = (int)PhotonNetwork.LocalPlayer.CustomProperties["PlayerID"];
         if (!isOccupied){
             isOccupied = true;
 
-            if (turn == 1)
+            if (PlayerId == PLAYER1)
             {
                 // oの印を表示する処理
                 if (oObject != null)
@@ -43,7 +48,7 @@ public class CellController : MonoBehaviour
                     return true;
                 }
             }
-            else if(turn == -1)
+            else if(PlayerId == PLAYER2)
             {
                 // xの印を表示する処理表示にする
                 if (xObject != null)

--- a/Assets/Scripts/ConnectNetwork.cs
+++ b/Assets/Scripts/ConnectNetwork.cs
@@ -26,7 +26,7 @@ public class ConnectNetwork : MonoBehaviourPunCallbacks
     // ランダムなルームへの参加が失敗した時に呼ばれるコールバック
     public override void OnJoinRandomFailed(short returnCode, string message){
         var initialProps = new ExitGames.Client.Photon.Hashtable();
-        initialProps["NextPlayerID"] = 1;
+        initialProps["NextPlayerID"] = 0;
 
         var roomOptions = new RoomOptions();
         roomOptions.MaxPlayers = 2;

--- a/Assets/Scripts/ConnectNetwork.cs
+++ b/Assets/Scripts/ConnectNetwork.cs
@@ -1,0 +1,38 @@
+using Photon.Pun;
+using Photon.Realtime;
+using UnityEngine;
+
+public class ConnectNetwork : MonoBehaviourPunCallbacks
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        // PhotonServerSettingsの設定内容を使ってマスターサーバーへ接続する
+        PhotonNetwork.ConnectUsingSettings();
+    }
+
+    // マスターサーバーへの接続が成功した時に呼ばれるコールバック
+    public override void OnConnectedToMaster()
+    {
+        PhotonNetwork.JoinRandomRoom();
+    }
+
+    // ゲームサーバーへの接続が成功した時に呼ばれるコールバック
+    public override void OnJoinedRoom()
+    {
+        Debug.Log("ルームへ参加しました!!");
+    }
+
+    // ランダムなルームへの参加が失敗した時に呼ばれるコールバック
+    public override void OnJoinRandomFailed(short returnCode, string message){
+        var initialProps = new ExitGames.Client.Photon.Hashtable();
+        initialProps["NextPlayerID"] = 1;
+
+        var roomOptions = new RoomOptions();
+        roomOptions.MaxPlayers = 2;
+        roomOptions.CustomRoomProperties = initialProps;
+
+        // ランダムで参加できるルームが存在しないなら、新規でルームを作成する
+        PhotonNetwork.CreateRoom(null, roomOptions);
+    }
+}

--- a/Assets/Scripts/ConnectNetwork.cs.meta
+++ b/Assets/Scripts/ConnectNetwork.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf2ed46bad36265488ef58ae4aad5fd7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GManager.cs
+++ b/Assets/Scripts/GManager.cs
@@ -1,11 +1,16 @@
+using Photon.Pun;
+using Photon.Realtime;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
-public class GManager : MonoBehaviour
+public class GManager : MonoBehaviourPunCallbacks
 {
-    private int turn = 1; // ×プレイヤーのターンかどうか
+    private int PLAYER1 = 0;
+    private int PLAYER2 = 1;
+    private int NO_PLAAYER = -1;
     private int turnNum = 0;
     public int[] board;
     private string resultText = "";
@@ -15,6 +20,10 @@ public class GManager : MonoBehaviour
     private void Start()
     {
         board = new int[9];
+        for (int i = 0; i < 9; i++){
+            board[i] = -1;
+        }
+
         lines = new GameObject[8];
         lines[0] = GameObject.Find("Line");
         lines[1] = GameObject.Find("Line (1)");
@@ -37,24 +46,48 @@ public class GManager : MonoBehaviour
             Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
             RaycastHit2D hit2D = Physics2D.Raycast((Vector2)ray.origin, (Vector2)ray.direction);
 
-            if (hit2D)
+            int playerId = (int)PhotonNetwork.LocalPlayer.CustomProperties["PlayerID"];
+            if (hit2D && (turnNum % 2) == playerId)
             {
                 GameObject cell = hit2D.collider.gameObject;
-                Debug.Log("ヒットしました！");
-
-                if (!cell.GetComponent<CellController>().IsOccupied())
+                if (board[cell.GetComponent<CellController>().getIndex()] == NO_PLAAYER)
                 {
-                    turnNum++;
                     PlaceSymbol(cell);
+                    photonView.RPC(nameof(countUpTurnNum), RpcTarget.All);
                 }
             }
         }
 
-        if(Input.GetKey(KeyCode.Space) && turn == 0)
+        if(Input.GetKey(KeyCode.Space) && turnNum == 0)
         {
             SceneManager.LoadScene(1);
         }
     }
+
+    [PunRPC]
+    private void countUpTurnNum(){
+        turnNum++;
+    }
+
+    [PunRPC]
+    public void RpcSetBoard(int index, int ox){
+        if (0 <= index && index <= 8){
+            board[index] = ox;
+        } else {
+            Debug.Log("invalid index...");
+        }
+    }
+
+    public int getBoard(int index){
+        if (0 <= index && index <= 8){
+            return board[index];
+        } else {
+            Debug.Log("invalid index...");
+        }
+
+        return -2;
+    }
+
 
     private void OnGUI()
     {
@@ -70,76 +103,80 @@ public class GManager : MonoBehaviour
 
     private void PlaceSymbol(GameObject cell)
     {
+        int playerId = (int)PhotonNetwork.LocalPlayer.CustomProperties["PlayerID"];
         if(cell.GetComponent<CellController>().MarkCell())
         {
             int index = cell.GetComponent<CellController>().getIndex();
-            board[index] = turn;
+            board[index] = playerId;
             isFinish();
-            turn = -turn;
         } 
     }
 
     private bool isFinish()
     {
-        if(board[0] != 0 && board[0] == board[1] && board[0] == board[2])
+        if(isLine(board[0], board[1], board[2]))
         {
-            lines[0].SetActive(true);
-            setText();
+            photonView.RPC(nameof(displayResult), RpcTarget.All, 0);
             return true;
-        }else if(board[3] != 0 && board[3] == board[4] && board[3] == board[5])
+        }else if(isLine(board[3], board[4], board[5]))
         {
-            lines[1].SetActive(true);
-            setText();
+            photonView.RPC(nameof(displayResult), RpcTarget.All, 1);
             return true;
-        }else if(board[6] != 0 && board[6] == board[7] && board[6] == board[8])
+        }else if(isLine(board[6], board[7], board[8]))
         {
-            lines[2].SetActive(true);
-            setText();
+            photonView.RPC(nameof(displayResult), RpcTarget.All, 2);
             return true;
-        }else if(board[0] != 0 && board[0] == board[3] && board[0] == board[6])
+        }else if(isLine(board[0], board[3], board[6]))
         {
-            lines[3].SetActive(true);
-            setText();
+            photonView.RPC(nameof(displayResult), RpcTarget.All, 3);
             return true;
-        }else if(board[1] != 0 && board[1] == board[4] && board[1] == board[7])
+        }else if(isLine(board[1], board[4], board[7]))
         {
-            lines[4].SetActive(true);
-            setText();
+            photonView.RPC(nameof(displayResult), RpcTarget.All, 4);
             return true;
-        }else if(board[2] != 0 && board[2] == board[5] && board[2] == board[8])
+        }else if(isLine(board[2], board[5], board[8]))
         {
-            lines[5].SetActive(true);
-            setText();
+            photonView.RPC(nameof(displayResult), RpcTarget.All, 5);
             return true;
-        }else if(board[0] != 0 && board[0] == board[4] && board[0] == board[8])
+        }else if(isLine(board[0], board[4], board[8]))
         {
-            lines[6].SetActive(true);
-            setText();
+            photonView.RPC(nameof(displayResult), RpcTarget.All, 6);
             return true;
-        }else if(board[2] != 0 && board[2] == board[4] && board[2] == board[6])
+        }else if(isLine(board[2], board[4], board[6]))
         {
-            lines[7].SetActive(true);
-            setText();
+            photonView.RPC(nameof(displayResult), RpcTarget.All, 7);
             return true;
         }else if (turnNum == 9)
         {
             resultText = "引き分けです";
-            turn = 0;
             return true;
         }
         return false;
     }
 
-    private void setText(){
-        if (turn == 1)
+    private bool isLine(int elem1, int elem2, int elem3)
+    {
+        return (elem1 != -1) && (elem1 == elem2) && (elem1 == elem3);
+    }
+
+    private void displayText(){
+        if ((turnNum % 2) == PLAYER1)
         {
             resultText = "Oの勝ちです";
         }
-        else if (turn == -1)
+        else if ((turnNum % 2) == PLAYER2)
         {
             resultText = "Xの勝ちです";
         }
-        turn = 0;
     }
 
+    [PunRPC]
+    private void displayResult(int index){
+        lines[index].SetActive(true);
+        displayText();
+    }
+
+    public int getTurnNum(){
+        return turnNum;
+    }
 }

--- a/Assets/Scripts/GManager.cs
+++ b/Assets/Scripts/GManager.cs
@@ -70,7 +70,7 @@ public class GManager : MonoBehaviour
 
     private void PlaceSymbol(GameObject cell)
     {
-        if(cell.GetComponent<CellController>().MarkCell(turn))
+        if(cell.GetComponent<CellController>().MarkCell())
         {
             int index = cell.GetComponent<CellController>().getIndex();
             board[index] = turn;

--- a/Assets/Scripts/PlayerManager.cs
+++ b/Assets/Scripts/PlayerManager.cs
@@ -21,6 +21,7 @@ public class PlayerManager : MonoBehaviourPunCallbacks
             {"NextPlayerID", nextPlayerID + 1}
         };
         PhotonNetwork.CurrentRoom.SetCustomProperties(roomUpdateProps);
+
     }
 
     public override void OnJoinedRoom()

--- a/Assets/Scripts/PlayerManager.cs
+++ b/Assets/Scripts/PlayerManager.cs
@@ -1,0 +1,32 @@
+using Photon.Pun;
+using Photon.Realtime;
+using UnityEngine;
+
+public class PlayerManager : MonoBehaviourPunCallbacks
+{
+    void AssignPlayerID()
+    {
+        int nextPlayerID = (int)PhotonNetwork.CurrentRoom.CustomProperties["NextPlayerID"];
+        
+        // プレイヤーのカスタムプロパティとしてIDを設定
+        ExitGames.Client.Photon.Hashtable playerProps = new ExitGames.Client.Photon.Hashtable
+        {
+            {"PlayerID", nextPlayerID}
+        };
+        PhotonNetwork.LocalPlayer.SetCustomProperties(playerProps);
+
+        // 次のプレイヤーIDを更新
+        ExitGames.Client.Photon.Hashtable roomUpdateProps = new ExitGames.Client.Photon.Hashtable
+        {
+            {"NextPlayerID", nextPlayerID + 1}
+        };
+        PhotonNetwork.CurrentRoom.SetCustomProperties(roomUpdateProps);
+    }
+
+    public override void OnJoinedRoom()
+    {
+        AssignPlayerID();
+    }
+
+
+}

--- a/Assets/Scripts/PlayerManager.cs.meta
+++ b/Assets/Scripts/PlayerManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a7b3df40e87e29043b72dc9dc39c2853
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/BurstAotSettings_StandaloneWindows.json
+++ b/ProjectSettings/BurstAotSettings_StandaloneWindows.json
@@ -1,0 +1,18 @@
+{
+  "MonoBehaviour": {
+    "Version": 4,
+    "EnableBurstCompilation": true,
+    "EnableOptimisations": true,
+    "EnableSafetyChecks": false,
+    "EnableDebugInAllBuilds": false,
+    "DebugDataKind": 1,
+    "EnableArmv9SecurityFeatures": false,
+    "CpuMinTargetX32": 0,
+    "CpuMaxTargetX32": 0,
+    "CpuMinTargetX64": 0,
+    "CpuMaxTargetX64": 0,
+    "CpuTargetsX32": 6,
+    "CpuTargetsX64": 72,
+    "OptimizeFor": 0
+  }
+}

--- a/ProjectSettings/CommonBurstAotSettings.json
+++ b/ProjectSettings/CommonBurstAotSettings.json
@@ -1,0 +1,6 @@
+{
+  "MonoBehaviour": {
+    "Version": 4,
+    "DisabledWarnings": ""
+  }
+}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -42,8 +42,8 @@ PlayerSettings:
   m_SplashScreenLogos: []
   m_VirtualRealitySplashScreen: {fileID: 0}
   m_HolographicTrackingLossScreen: {fileID: 0}
-  defaultScreenWidth: 1920
-  defaultScreenHeight: 1080
+  defaultScreenWidth: 600
+  defaultScreenHeight: 600
   defaultScreenWidthWeb: 960
   defaultScreenHeightWeb: 600
   m_StereoRenderingPath: 0
@@ -90,7 +90,7 @@ PlayerSettings:
   bakeCollisionMeshes: 0
   forceSingleInstance: 0
   useFlipModelSwapchain: 1
-  resizableWindow: 0
+  resizableWindow: 1
   useMacAppStoreValidation: 0
   macAppStoreCategory: public.app-category.games
   gpuSkinning: 0
@@ -101,7 +101,7 @@ PlayerSettings:
   xboxEnableFitness: 0
   visibleInBackground: 1
   allowFullscreenSwitch: 1
-  fullscreenMode: 1
+  fullscreenMode: 3
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
   xboxEnableGuest: 0
@@ -593,7 +593,24 @@ PlayerSettings:
   webGLMemoryGeometricGrowthStep: 0.2
   webGLMemoryGeometricGrowthCap: 96
   webGLPowerPreference: 2
-  scriptingDefineSymbols: {}
+  scriptingDefineSymbols:
+    Android: PHOTON_UNITY_NETWORKING;PUN_2_0_OR_NEWER;PUN_2_OR_NEWER;PUN_2_19_OR_NEWER
+    EmbeddedLinux: PHOTON_UNITY_NETWORKING;PUN_2_0_OR_NEWER;PUN_2_OR_NEWER;PUN_2_19_OR_NEWER
+    GameCoreScarlett: PHOTON_UNITY_NETWORKING;PUN_2_0_OR_NEWER;PUN_2_OR_NEWER;PUN_2_19_OR_NEWER
+    GameCoreXboxOne: PHOTON_UNITY_NETWORKING;PUN_2_0_OR_NEWER;PUN_2_OR_NEWER;PUN_2_19_OR_NEWER
+    LinuxHeadlessSimulation: PHOTON_UNITY_NETWORKING;PUN_2_0_OR_NEWER;PUN_2_OR_NEWER;PUN_2_19_OR_NEWER
+    Nintendo Switch: PHOTON_UNITY_NETWORKING;PUN_2_0_OR_NEWER;PUN_2_OR_NEWER;PUN_2_19_OR_NEWER
+    PS4: PHOTON_UNITY_NETWORKING;PUN_2_0_OR_NEWER;PUN_2_OR_NEWER;PUN_2_19_OR_NEWER
+    PS5: PHOTON_UNITY_NETWORKING;PUN_2_0_OR_NEWER;PUN_2_OR_NEWER;PUN_2_19_OR_NEWER
+    QNX: PHOTON_UNITY_NETWORKING;PUN_2_0_OR_NEWER;PUN_2_OR_NEWER;PUN_2_19_OR_NEWER
+    Stadia: PHOTON_UNITY_NETWORKING;PUN_2_0_OR_NEWER;PUN_2_OR_NEWER;PUN_2_19_OR_NEWER
+    Standalone: PHOTON_UNITY_NETWORKING;PUN_2_0_OR_NEWER;PUN_2_OR_NEWER;PUN_2_19_OR_NEWER
+    VisionOS: PHOTON_UNITY_NETWORKING;PUN_2_0_OR_NEWER;PUN_2_OR_NEWER;PUN_2_19_OR_NEWER
+    WebGL: PHOTON_UNITY_NETWORKING;PUN_2_0_OR_NEWER;PUN_2_OR_NEWER;PUN_2_19_OR_NEWER
+    Windows Store Apps: PHOTON_UNITY_NETWORKING;PUN_2_0_OR_NEWER;PUN_2_OR_NEWER;PUN_2_19_OR_NEWER
+    XboxOne: PHOTON_UNITY_NETWORKING;PUN_2_0_OR_NEWER;PUN_2_OR_NEWER;PUN_2_19_OR_NEWER
+    iPhone: PHOTON_UNITY_NETWORKING;PUN_2_0_OR_NEWER;PUN_2_OR_NEWER;PUN_2_19_OR_NEWER
+    tvOS: PHOTON_UNITY_NETWORKING;PUN_2_0_OR_NEWER;PUN_2_OR_NEWER;PUN_2_19_OR_NEWER
   additionalCompilerArguments: {}
   platformArchitecture: {}
   scriptingBackend: {}


### PR DESCRIPTION
## RPC
… [PunRPC]をつけることで戻り値のない関数の処理の同期ができる
- ボード配列の更新処理
- 結果表示(～の勝利, 揃った場所の線の表示)
- oxを置く処理
## カスタムプロパティ
... ルーム・プレイヤーに対して共有の変数を付与(同期する)ことができる
- 最大収容人数(ルーム)
- プレイヤーID(プレイヤー)

※最大の注意点はカスタムプロパティは同期がとれていないので可変のものはおかないということ