### PR TITLE
fix:勝敗が決定したときにスペースキーを押すと再戦できるように修正

### DIFF
--- a/Assets/Scripts/GManager.cs
+++ b/Assets/Scripts/GManager.cs
@@ -58,7 +58,7 @@ public class GManager : MonoBehaviourPunCallbacks
             }
         }
 
-        if(Input.GetKey(KeyCode.Space) && turnNum == 0)
+        if(Input.GetKey(KeyCode.Space) && turnNum == 9)
         {
             SceneManager.LoadScene(1);
         }
@@ -168,6 +168,8 @@ public class GManager : MonoBehaviourPunCallbacks
         {
             resultText = "Xの勝ちです";
         }
+
+        turnNum = 8;
     }
 
     [PunRPC]


### PR DESCRIPTION
## 再戦可能な場合
- 全ターン終了時(9ターン目)までいったとき
- 勝敗が決まったとき
※勝敗が決まったに関しては強制的にターン数を変更して実装
→そのため勝敗が決定後にマスにOXを置くとターン数が10以上になるバグが発生する可能性はあるかもしれない